### PR TITLE
Declare class & methods as `open`

### DIFF
--- a/Source/Classes/OverlayContainerViewController.swift
+++ b/Source/Classes/OverlayContainerViewController.swift
@@ -31,7 +31,7 @@ open class OverlayContainerViewController: UIViewController {
     }
 
     /// The container's delegate.
-    public var delegate: OverlayContainerViewControllerDelegate? {
+    public weak var delegate: OverlayContainerViewControllerDelegate? {
         set {
             configuration.delegate = newValue
             configuration.invalidateOverlayMetrics()

--- a/Source/Classes/OverlayContainerViewController.swift
+++ b/Source/Classes/OverlayContainerViewController.swift
@@ -57,7 +57,7 @@ open class OverlayContainerViewController: UIViewController {
         return viewControllers.last
     }
 
-    public override var childForStatusBarStyle: UIViewController? {
+    open override var childForStatusBarStyle: UIViewController? {
         return topViewController
     }
 

--- a/Source/Classes/OverlayContainerViewController.swift
+++ b/Source/Classes/OverlayContainerViewController.swift
@@ -15,7 +15,7 @@ import UIKit
 ///
 /// OverlayContainer uses the last view controller of its viewControllers as the overlay view controller.
 /// It stacks the other view controllers on top of each other, if any, and adds them underneath the overlay view controller.
-public class OverlayContainerViewController: UIViewController {
+open class OverlayContainerViewController: UIViewController {
 
     /// `OverlayStyle` defines how the overlay view controllers will be constrained in the container.
     public enum OverlayStyle {
@@ -109,18 +109,18 @@ public class OverlayContainerViewController: UIViewController {
 
     // MARK: - UIViewController
 
-    public override func loadView() {
+    open override func loadView() {
         view = PassThroughView()
         loadContainerViews()
         loadOverlayViews()
     }
 
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         setUpPanGesture()
     }
 
-    public override func viewWillLayoutSubviews() {
+    open override func viewWillLayoutSubviews() {
         // (gz) 2019-06-10 According to the documentation, the default implementation of
         // `viewWillLayoutSubviews` does nothing.
         // Nethertheless in its `Changing Constraints` Guide, Apple recommends to call it.
@@ -155,7 +155,7 @@ public class OverlayContainerViewController: UIViewController {
     /// - parameter completion: The block to execute after the translation finishes.
     ///   This block has no return value and takes no parameters. You may specify nil for this parameter.
     ///
-    public func moveOverlay(toNotchAt index: Int, animated: Bool, completion: (() -> Void)? = nil) {
+    open func moveOverlay(toNotchAt index: Int, animated: Bool, completion: (() -> Void)? = nil) {
         loadViewIfNeeded()
         translationController?.scheduleOverlayTranslation(
             .toIndex(index),
@@ -173,7 +173,7 @@ public class OverlayContainerViewController: UIViewController {
     /// and animates the translation.
     /// Use `moveOverlay(toNotchAt:animated:completion:)` to override this behavior.
     ///
-    public func invalidateNotchHeights() {
+    open func invalidateNotchHeights() {
         configuration.invalidateOverlayMetrics()
         translationController?.scheduleOverlayTranslation(
             .basedOnTargetPolicy,


### PR DESCRIPTION
This change is motivated by wanting to put the top level OverlayContainerViewController inside a navigationViewController. As a standalone class it wasn't setting the navigationItems appropriately.

With these changes I could create a subclass and set it as the delegate which really simplified my usage and class hierarchy.