### PR TITLE
Prevent loading the view when setting a delegate to the overlayContainer

### DIFF
--- a/Source/Classes/OverlayContainerViewController.swift
+++ b/Source/Classes/OverlayContainerViewController.swift
@@ -274,7 +274,7 @@ open class OverlayContainerViewController: UIViewController {
 
     private func setNeedsOverlayContainerHeightUpdate() {
         needsOverlayContainerHeightUpdate = true
-        view.setNeedsLayout()
+        viewIfLoaded?.setNeedsLayout()
     }
 
     private func updateOverlayContainerConstraints() {


### PR DESCRIPTION
Currently setting a delegate to the overlay container calls `setNeedsOverlayContainerHeightUpdate` which in times calls `view.setNeedsLayout` causing the view to load while its not always necessary.
Calling `setNeedsLayout` on `viewIfLoaded` instead of `view` fixes this issue.